### PR TITLE
pump numpy version to '1.26.4'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ iniconfig==2.0.0
 Jinja2==3.1.2
 MarkupSafe==2.1.1
 nodeenv==1.8.0
-numpy==1.23.5
+numpy==1.26.4
 packaging==23.2
 pandas==1.5.2
 platformdirs==4.0.0


### PR DESCRIPTION
Fix for `pkgutil.ImpImporter` AttributeError in Python 3.12

When using Python 3.12 (default at lxplus now), you will encounter the following error:

```plaintext
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
```
This is actually coming when installing requirements (NumPy) to a new environment. Pumping it to `1.26.4` fixes this problem. 