### PR TITLE
feat: add lhcb-sim11-dev and a few platforms (gcc13, arm)

### DIFF
--- a/status_checker.py
+++ b/status_checker.py
@@ -34,6 +34,7 @@ class StatusChecker:
     slots_to_check = [
         "lhcb-sim10-dev",
         "lhcb-sim10",
+        "lhcb-sim11-dev",
         "lhcb-sim11",
     ]
 
@@ -55,6 +56,8 @@ class StatusChecker:
         "x86_64_v2-centos7-gcc12-opt",
         "x86_64_v2-centos7-gcc12+detdesc-opt",
         "x86_64_v2-el9-gcc12-opt",
+        "x86_64_v2-el9-gcc13-opt",
+        "armv8.1_a-el9-gcc13-opt",
     ]
 
     result_types = {


### PR DESCRIPTION
In the slides to prepare the new DQCS exam, the `lhcb-sim11-dev` slot is mentioned.
Also, I added `gcc13` and `arm` platforms, because we will likely need to check them soon If I understand correctly.